### PR TITLE
Refactor render_html_list

### DIFF
--- a/src/http/commands/help/presenter.rb
+++ b/src/http/commands/help/presenter.rb
@@ -77,7 +77,7 @@ module Foobara
               when ::Hash
                 html << "<ul>" unless skip_wrapper
                 data.each do |key, value|
-                  html << "<li>#{key}"
+                  html << "<li><strong>#{key} </strong>"
                   html << "<ul>"
                   html << render_html_list(value, skip_wrapper: true)
                   html << "</ul>"
@@ -137,24 +137,30 @@ module Foobara
                     if key.to_s == "type"
                       value = root_manifest.lookup_path(key, value)
                     end
-                    html << "<li>#{key}"
-                    html << "<ul>"
+                    html << "<li><strong>#{key}: </strong>"
                     html << render_html_list(value, skip_wrapper: true)
-                    html << "</ul>"
                     html << "</li>"
                   end
                   html << "</ul>" unless skip_wrapper
                 end
-              when Manifest::Type, Manifest::Command, Manifest::Error
+              when Manifest::Type
+                html << foobara_reference_link(data)
+              when Manifest::Command
                 html << "<li>"
+                html << foobara_reference_link(data)
+                html << "</li>"
+              when Manifest::Error
+                html << "<li>"
+                html << "<strong>Error: </strong>"
                 html << foobara_reference_link(data)
                 html << "</li>"
               when Manifest::PossibleError
                 html << render_html_list(data.error)
+              when String
+                html << data
               else
                 html << "<li>#{data}</li>"
               end
-
               html
             end
 

--- a/src/http/commands/help/templates/command.html.erb
+++ b/src/http/commands/help/templates/command.html.erb
@@ -2,10 +2,10 @@
 <p><%= description %></p>
 
 <h2>Inputs</h2>
-<%= render_html_list(inputs_type) %>
+<%= render_html_parent(inputs_type) %>
 
 <h2>Result</h2>
-<%= render_html_list(result_type) %>
+<%= render_html_parent(result_type) %>
 
 <h2>Possible Errors</h2>
-<%= render_html_list(possible_errors) %>
+<%= render_html_parent(possible_errors) %>


### PR DESCRIPTION
This PR refactors the `render_html_list` function to minmize the usage of unnecessary `<ul>` and `<li>` tags

I tried improving the UI but it messed up with the other components of the html page so I couldn't do much about it.

Please test it out extensively with different examples and let me know if anything breaks

Thanks!!!